### PR TITLE
Feature: Podcast details page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.5",
+        "react-router-dom": "^6.9.0",
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.9",
         "typescript": "^4.9.5",
@@ -3720,6 +3721,14 @@
         "react-redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.4.0.tgz",
+      "integrity": "sha512-BJ9SxXux8zAg991UmT8slpwpsd31K1dHHbD3Ba4VzD+liLQ4WAMSxQp2d2ZPRPfN0jN2NPRowcSSoM7lCaF08Q==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -27232,6 +27241,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.9.0.tgz",
+      "integrity": "sha512-51lKevGNUHrt6kLuX3e/ihrXoXCa9ixY/nVWRLlob4r/l0f45x3SzBvYJe3ctleLUQQ5fVa4RGgJOTH7D9Umhw==",
+      "dependencies": {
+        "@remix-run/router": "1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.9.0.tgz",
+      "integrity": "sha512-/seUAPY01VAuwkGyVBPCn1OXfVbaWGGu4QN9uj0kCPcTyNYgL1ldZpxZUpRU7BLheKQI4Twtl/OW2nHRF1u26Q==",
+      "dependencies": {
+        "@remix-run/router": "1.4.0",
+        "react-router": "6.9.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
+    "react-router-dom": "^6.9.0",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.9",
     "typescript": "^4.9.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,48 +1,12 @@
-import { useEffect } from 'react';
-import { useAppDispatch, useAppSelector } from 'app/hooks';
+import { RouterProvider } from 'react-router-dom';
+import { router } from 'app/router';
 import { AppHeader } from 'components';
-import {
-  fetchPodcasts,
-  selectFilteredPodcasts,
-  selectFilter,
-  selectLastFetch,
-  selectStatus,
-  updateFilter,
-} from 'features/podcasts';
-import { HomePage } from 'pages';
-import { isWithin24Hours } from 'utils';
 
 function App() {
-  const podcasts = useAppSelector(selectFilteredPodcasts);
-  const lastFetch = useAppSelector(selectLastFetch);
-  const podcastsStatus = useAppSelector(selectStatus);
-  const filterValue = useAppSelector(selectFilter);
-  const dispatch = useAppDispatch();
-
-  useEffect(() => {
-    if (podcastsStatus !== 'loading') {
-      if (!lastFetch || !isWithin24Hours(lastFetch)) {
-        dispatch(fetchPodcasts());
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const onFilterChange: React.ChangeEventHandler<HTMLInputElement> = (
-    event
-  ) => {
-    dispatch(updateFilter(event.target.value));
-  };
-
   return (
     <>
       <AppHeader />
-      <HomePage
-        podcasts={podcasts}
-        filterResults={podcasts.length}
-        filterValue={filterValue}
-        onFilterChange={onFilterChange}
-      />
+      <RouterProvider router={router} />
     </>
   );
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -55,5 +55,21 @@ export const client = (() => {
         data: data.feed.entry,
       };
     },
+    fetchPodcastDetails: async function (podcastId: string) {
+      const response = await get(`${baseUrl}/lookup?id=${podcastId}`);
+
+      let data;
+
+      try {
+        data = JSON.parse(response.data.contents);
+      } catch (err) {
+        return Promise.reject(new Error("Couldn't parse response data."));
+      }
+
+      return {
+        status: response.status,
+        data: data.resultCount > 0 ? data.results[0] : null,
+      };
+    },
   };
 })();

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -56,7 +56,11 @@ export const client = (() => {
       };
     },
     fetchPodcastDetails: async function (podcastId: string) {
-      const response = await get(`${baseUrl}/lookup?id=${podcastId}`);
+      // URL borrowed from:
+      // https://stackoverflow.com/questions/72841863/how-do-i-get-all-the-episodes-for-an-itunes-api-podcast
+      const response = await get(
+        `${baseUrl}/lookup?id=${podcastId}&media=podcast&entity=podcastEpisode`
+      );
 
       let data;
 
@@ -68,7 +72,7 @@ export const client = (() => {
 
       return {
         status: response.status,
-        data: data.resultCount > 0 ? data.results[0] : null,
+        data: data?.results,
       };
     },
   };

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,0 +1,9 @@
+import { HomePageRoute } from 'routes';
+import { createBrowserRouter } from 'react-router-dom';
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <HomePageRoute />,
+  },
+]);

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,9 +1,13 @@
-import { HomePageRoute } from 'routes';
 import { createBrowserRouter } from 'react-router-dom';
+import { HomePageRoute, PodcastDetailsPageRoute } from 'routes';
 
 export const router = createBrowserRouter([
   {
     path: '/',
     element: <HomePageRoute />,
+  },
+  {
+    path: '/podcast/:podcastId',
+    element: <PodcastDetailsPageRoute />,
   },
 ]);

--- a/src/features/podcasts/PodcastDetailsCard/PodcastDetailsCard.stories.tsx
+++ b/src/features/podcasts/PodcastDetailsCard/PodcastDetailsCard.stories.tsx
@@ -1,0 +1,22 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { PodcastDetailsCard } from './PodcastDetailsCard';
+
+export default {
+  title: 'Features/Podcasts/PodcastDetailsCard',
+  component: PodcastDetailsCard,
+  decorators: [(Story) => <div style={{ maxWidth: '300px' }}>{Story()}</div>],
+} as ComponentMeta<typeof PodcastDetailsCard>;
+
+const PodcastDetailsCardTemplate: ComponentStory<typeof PodcastDetailsCard> = (
+  props
+) => <PodcastDetailsCard {...props} />;
+
+export const Default = PodcastDetailsCardTemplate.bind({});
+
+Default.args = {
+  author: 'Song Exploder',
+  coverUrl: 'https://via.placeholder.com/170x170',
+  description:
+    'A podcast where musicians take apart their songs, and piece by piece, tell the story of how they were made.',
+  title: 'Song Exploder',
+};

--- a/src/features/podcasts/PodcastDetailsCard/PodcastDetailsCard.styles.ts
+++ b/src/features/podcasts/PodcastDetailsCard/PodcastDetailsCard.styles.ts
@@ -1,22 +1,23 @@
 import styled from 'styled-components';
 
 export const MainContainer = styled.aside`
+  border-radius: 0.3rem;
   box-shadow: ${({ theme }) => theme.palette.shadow};
+  color: ${({ theme }) => theme.palette.text.primary};
   display: flex;
   flex-direction: column;
   padding: 0 0.8rem;
-  color: ${({ theme }) => theme.palette.text.primary};
 `;
 
 export const CoverContainer = styled.div`
-  padding: 1.5rem 2rem;
   display: flex;
   justify-content: center;
+  padding: 1.5rem 2rem;
 `;
 
 export const TitleContainer = styled.div`
-  border-top: 1px solid lightgray;
   border-bottom: 1px solid lightgray;
+  border-top: 1px solid lightgray;
   padding: 1.5rem 1rem;
 `;
 

--- a/src/features/podcasts/PodcastDetailsCard/PodcastDetailsCard.styles.ts
+++ b/src/features/podcasts/PodcastDetailsCard/PodcastDetailsCard.styles.ts
@@ -32,6 +32,7 @@ export const DescriptionContainer = styled.div`
 
 export const PodcastCover = styled.img`
   border-radius: 0.3rem;
+  height: 170px;
 `;
 
 export const PodcastTitle = styled.h2`

--- a/src/features/podcasts/PodcastDetailsCard/PodcastDetailsCard.styles.ts
+++ b/src/features/podcasts/PodcastDetailsCard/PodcastDetailsCard.styles.ts
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+
+export const MainContainer = styled.aside`
+  box-shadow: ${({ theme }) => theme.palette.shadow};
+  display: flex;
+  flex-direction: column;
+  padding: 0 0.8rem;
+  color: ${({ theme }) => theme.palette.text.primary};
+`;
+
+export const CoverContainer = styled.div`
+  padding: 1.5rem 2rem;
+  display: flex;
+  justify-content: center;
+`;
+
+export const TitleContainer = styled.div`
+  border-top: 1px solid lightgray;
+  border-bottom: 1px solid lightgray;
+  padding: 1.5rem 1rem;
+`;
+
+export const DescriptionContainer = styled.div`
+  padding: 1.5rem 1rem;
+
+  & > p:first-child {
+    font-weight: bold;
+    margin-bottom: 0.5rem;
+  }
+`;
+
+export const PodcastCover = styled.img`
+  border-radius: 0.3rem;
+`;
+
+export const PodcastTitle = styled.h2`
+  font-size: 1.3rem;
+  margin-bottom: 0.3rem;
+`;
+
+export const PodcastAuthor = styled.p`
+  font-size: 1.15rem;
+  font-style: italic;
+`;
+
+export const PodcastDescription = styled.p`
+  font-style: italic;
+`;

--- a/src/features/podcasts/PodcastDetailsCard/PodcastDetailsCard.tsx
+++ b/src/features/podcasts/PodcastDetailsCard/PodcastDetailsCard.tsx
@@ -1,0 +1,41 @@
+import { FC } from 'react';
+import {
+  CoverContainer,
+  DescriptionContainer,
+  MainContainer,
+  PodcastAuthor,
+  PodcastCover,
+  PodcastDescription,
+  PodcastTitle,
+  TitleContainer,
+} from './PodcastDetailsCard.styles';
+
+interface PodcastDetailsCardProps {
+  author: string;
+  coverUrl: string;
+  description: string;
+  title: string;
+}
+
+export const PodcastDetailsCard: FC<PodcastDetailsCardProps> = ({
+  author,
+  coverUrl,
+  description,
+  title,
+}) => {
+  return (
+    <MainContainer>
+      <CoverContainer>
+        <PodcastCover src={coverUrl} />
+      </CoverContainer>
+      <TitleContainer>
+        <PodcastTitle>{title}</PodcastTitle>
+        <PodcastAuthor>by&nbsp;{author}</PodcastAuthor>
+      </TitleContainer>
+      <DescriptionContainer>
+        <p>Description:</p>
+        <PodcastDescription>{description}</PodcastDescription>
+      </DescriptionContainer>
+    </MainContainer>
+  );
+};

--- a/src/features/podcasts/PodcastDetailsCard/PodcastDetailsCard.tsx
+++ b/src/features/podcasts/PodcastDetailsCard/PodcastDetailsCard.tsx
@@ -12,6 +12,7 @@ import {
 
 interface PodcastDetailsCardProps {
   author: string;
+  className?: string;
   coverUrl: string;
   description: string;
   title: string;
@@ -19,12 +20,13 @@ interface PodcastDetailsCardProps {
 
 export const PodcastDetailsCard: FC<PodcastDetailsCardProps> = ({
   author,
+  className,
   coverUrl,
   description,
   title,
 }) => {
   return (
-    <MainContainer>
+    <MainContainer className={className}>
       <CoverContainer>
         <PodcastCover src={coverUrl} />
       </CoverContainer>

--- a/src/features/podcasts/PodcastDetailsCard/PodcastDetailsCard.tsx
+++ b/src/features/podcasts/PodcastDetailsCard/PodcastDetailsCard.tsx
@@ -15,6 +15,7 @@ interface PodcastDetailsCardProps {
   className?: string;
   coverUrl: string;
   description: string;
+  podcastId: string;
   title: string;
 }
 
@@ -23,10 +24,11 @@ export const PodcastDetailsCard: FC<PodcastDetailsCardProps> = ({
   className,
   coverUrl,
   description,
+  podcastId,
   title,
 }) => {
   return (
-    <MainContainer className={className}>
+    <MainContainer className={className} id={`podcast-${podcastId}`}>
       <CoverContainer>
         <PodcastCover src={coverUrl} />
       </CoverContainer>

--- a/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.stories.tsx
+++ b/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.stories.tsx
@@ -1,0 +1,35 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { PodcastEpisodesTable } from './PodcastEpisodesTable';
+
+export default {
+  title: 'Features/Podcasts/PodcastEpisodesTable',
+  component: PodcastEpisodesTable,
+} as ComponentMeta<typeof PodcastEpisodesTable>;
+
+const PodcastEpisodesTableTemplate: ComponentStory<
+  typeof PodcastEpisodesTable
+> = (props) => <PodcastEpisodesTable {...props} />;
+
+export const Default = PodcastEpisodesTableTemplate.bind({});
+
+Default.args = {
+  children: (
+    <>
+      <PodcastEpisodesTable.Row
+        title="Podcast 1"
+        date="19/03/2023"
+        duration="15:45"
+      />
+      <PodcastEpisodesTable.Row
+        title="Podcast 2"
+        date="19/03/2023"
+        duration="15:45"
+      />
+      <PodcastEpisodesTable.Row
+        title="Podcast 3"
+        date="19/03/2023"
+        duration="15:45"
+      />
+    </>
+  ),
+};

--- a/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.stories.tsx
+++ b/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.stories.tsx
@@ -16,19 +16,22 @@ Default.args = {
   children: (
     <>
       <PodcastEpisodesTable.Row
+        date="19/03/2023"
+        duration="15:45"
+        episodeId="1"
         title="Podcast 1"
-        date="19/03/2023"
-        duration="15:45"
       />
       <PodcastEpisodesTable.Row
+        date="19/03/2023"
+        duration="15:45"
+        episodeId="2"
         title="Podcast 2"
-        date="19/03/2023"
-        duration="15:45"
       />
       <PodcastEpisodesTable.Row
-        title="Podcast 3"
         date="19/03/2023"
         duration="15:45"
+        episodeId="3"
+        title="Podcast 3"
       />
     </>
   ),

--- a/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.styles.ts
+++ b/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.styles.ts
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+export const Table = styled.div.attrs({ role: 'grid' })`
+  border-radius: 0.3rem;
+  box-shadow: ${({ theme }) => theme.palette.shadow};
+  padding: 1rem;
+`;
+
+export const TableColumnHeader = styled.div.attrs({ role: 'columnheader' })<{
+  align?: string;
+}>`
+  font-weight: bold;
+  text-align: ${({ align = 'left' }) => align};
+`;
+
+export const TableRowGroup = styled.div.attrs({ role: 'rowgroup' })`
+  [role='row']:nth-child(odd) {
+    background-color: #f8f8f8;
+  }
+`;
+
+export const TableRow = styled.div.attrs({ role: 'row' })`
+  border-bottom: 1px solid lightgray;
+  display: grid;
+  grid-template-columns: 70% 1fr 1fr;
+  padding: 0.8rem 1rem;
+`;
+
+export const TableCell = styled.div.attrs({ role: 'gridcell' })<{
+  align?: string;
+}>`
+  text-align: ${({ align = 'left' }) => align};
+`;

--- a/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.styles.ts
+++ b/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Table = styled.div.attrs({ role: 'grid' })`
   border-radius: 0.3rem;
@@ -22,12 +22,22 @@ export const TableRowGroup = styled.div.attrs({ role: 'rowgroup' })`
 export const TableRow = styled.div.attrs({ role: 'row' })`
   border-bottom: 1px solid lightgray;
   display: grid;
-  grid-template-columns: 70% 1fr 1fr;
+  grid-template-columns: 60% 1fr 1fr;
   padding: 0.8rem 1rem;
+  column-gap: 0.8rem;
 `;
 
 export const TableCell = styled.div.attrs({ role: 'gridcell' })<{
   align?: string;
+  noWrap?: boolean;
 }>`
   text-align: ${({ align = 'left' }) => align};
+
+  ${({ noWrap }) =>
+    noWrap &&
+    css`
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    `}
 `;

--- a/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.tsx
+++ b/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.tsx
@@ -35,7 +35,7 @@ PodcastEpisodesTable.Row = ({
   title: string;
 }) => (
   <TableRow id={`episode-${episodeId}`}>
-    <TableCell>{title}</TableCell>
+    <TableCell noWrap>{title}</TableCell>
     <TableCell align="center">{date}</TableCell>
     <TableCell align="center">{duration}</TableCell>
   </TableRow>

--- a/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.tsx
+++ b/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.tsx
@@ -7,9 +7,12 @@ import {
   TableRowGroup,
 } from './PodcastEpisodesTable.styles';
 
-export const PodcastEpisodesTable = ({ children }: PropsWithChildren) => {
+export const PodcastEpisodesTable = ({
+  className,
+  children,
+}: PropsWithChildren<{ className?: string }>) => {
   return (
-    <Table>
+    <Table className={className}>
       <TableRow>
         <TableColumnHeader>Title</TableColumnHeader>
         <TableColumnHeader align="center">Date</TableColumnHeader>

--- a/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.tsx
+++ b/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.tsx
@@ -1,0 +1,37 @@
+import { PropsWithChildren } from 'react';
+import {
+  Table,
+  TableCell,
+  TableColumnHeader,
+  TableRow,
+  TableRowGroup,
+} from './PodcastEpisodesTable.styles';
+
+export const PodcastEpisodesTable = ({ children }: PropsWithChildren) => {
+  return (
+    <Table>
+      <TableRow>
+        <TableColumnHeader>Title</TableColumnHeader>
+        <TableColumnHeader align="center">Date</TableColumnHeader>
+        <TableColumnHeader align="center">Duration</TableColumnHeader>
+      </TableRow>
+      <TableRowGroup>{children}</TableRowGroup>
+    </Table>
+  );
+};
+
+PodcastEpisodesTable.Row = ({
+  date,
+  duration,
+  title,
+}: {
+  date: string;
+  duration: string;
+  title: string;
+}) => (
+  <TableRow>
+    <TableCell>{title}</TableCell>
+    <TableCell align="center">{date}</TableCell>
+    <TableCell align="center">{duration}</TableCell>
+  </TableRow>
+);

--- a/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.tsx
+++ b/src/features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable.tsx
@@ -26,13 +26,15 @@ export const PodcastEpisodesTable = ({
 PodcastEpisodesTable.Row = ({
   date,
   duration,
+  episodeId,
   title,
 }: {
   date: string;
   duration: string;
+  episodeId: string;
   title: string;
 }) => (
-  <TableRow>
+  <TableRow id={`episode-${episodeId}`}>
     <TableCell>{title}</TableCell>
     <TableCell align="center">{date}</TableCell>
     <TableCell align="center">{duration}</TableCell>

--- a/src/features/podcasts/PodcastEpisodesTally/PodcastEpisodesTally.stories.tsx
+++ b/src/features/podcasts/PodcastEpisodesTally/PodcastEpisodesTally.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { PodcastEpisodesTally } from './PodcastEpisodesTally';
+
+export default {
+  title: 'Features/Podcasts/PodcastEpisodesTally',
+  component: PodcastEpisodesTally,
+} as ComponentMeta<typeof PodcastEpisodesTally>;
+
+const PodcastEpisodesTallyTemplate: ComponentStory<
+  typeof PodcastEpisodesTally
+> = (props) => <PodcastEpisodesTally {...props} />;
+
+export const Default = PodcastEpisodesTallyTemplate.bind({});
+
+Default.args = {
+  tally: 49,
+};

--- a/src/features/podcasts/PodcastEpisodesTally/PodcastEpisodesTally.styles.ts
+++ b/src/features/podcasts/PodcastEpisodesTally/PodcastEpisodesTally.styles.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const Container = styled.header`
+  border-radius: 0.3rem;
+  box-shadow: ${({ theme }) => theme.palette.shadow};
+  padding: 0.8rem;
+
+  h3 {
+    color: ${({ theme }) => theme.palette.text.primary};
+    font-size: 1.5rem;
+  }
+`;

--- a/src/features/podcasts/PodcastEpisodesTally/PodcastEpisodesTally.tsx
+++ b/src/features/podcasts/PodcastEpisodesTally/PodcastEpisodesTally.tsx
@@ -2,14 +2,16 @@ import { FC } from 'react';
 import { Container } from './PodcastEpisodesTally.styles';
 
 interface PodcastEpisodesTallyProps {
+  className?: string;
   tally?: number;
 }
 
 export const PodcastEpisodesTally: FC<PodcastEpisodesTallyProps> = ({
+  className,
   tally = 0,
 }) => {
   return (
-    <Container>
+    <Container className={className}>
       <h3>Episodes: {tally}</h3>
     </Container>
   );

--- a/src/features/podcasts/PodcastEpisodesTally/PodcastEpisodesTally.tsx
+++ b/src/features/podcasts/PodcastEpisodesTally/PodcastEpisodesTally.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react';
+import { Container } from './PodcastEpisodesTally.styles';
+
+interface PodcastEpisodesTallyProps {
+  tally?: number;
+}
+
+export const PodcastEpisodesTally: FC<PodcastEpisodesTallyProps> = ({
+  tally = 0,
+}) => {
+  return (
+    <Container>
+      <h3>Episodes: {tally}</h3>
+    </Container>
+  );
+};

--- a/src/features/podcasts/PodcastGrid/PodcastGrid.tsx
+++ b/src/features/podcasts/PodcastGrid/PodcastGrid.tsx
@@ -1,4 +1,6 @@
 import { FC } from 'react';
+import { Link } from 'react-router-dom';
+
 import { PodcastCard } from '../PodcastCard/PodcastCard';
 import { GridContainer } from './PodcastGrid.styles';
 
@@ -9,13 +11,14 @@ interface PodcastProps {
 export const PodcastGrid: FC<PodcastProps> = ({ podcasts }) => (
   <GridContainer>
     {podcasts.map(({ podcastId, coverUrl, title, author }) => (
-      <PodcastCard
-        key={podcastId}
-        podcastId={podcastId}
-        coverUrl={coverUrl}
-        title={title}
-        author={author}
-      />
+      <Link to={`/podcast/${podcastId}`} key={podcastId}>
+        <PodcastCard
+          podcastId={podcastId}
+          coverUrl={coverUrl}
+          title={title}
+          author={author}
+        />
+      </Link>
     ))}
   </GridContainer>
 );

--- a/src/features/podcasts/podcasts-selectors.ts
+++ b/src/features/podcasts/podcasts-selectors.ts
@@ -7,7 +7,8 @@ const selectPodcasts = (state: RootState) => state.podcasts;
 
 const selectors = podcastsAdapter.getSelectors(selectPodcasts);
 
-export const { selectAll: selectAllPodcasts } = selectors;
+export const { selectAll: selectAllPodcasts, selectById: selectPodcastById } =
+  selectors;
 
 export const selectLastFetch = (state: RootState) =>
   selectPodcasts(state).lastFetch;

--- a/src/features/podcasts/podcasts-slice.ts
+++ b/src/features/podcasts/podcasts-slice.ts
@@ -2,10 +2,18 @@ import {
   createSlice,
   createEntityAdapter,
   createAsyncThunk,
+  PayloadAction,
 } from '@reduxjs/toolkit';
 import { client } from 'api/client';
 import { setStoredPodcasts } from 'app/storage';
 import { adaptPodcastFromResponse } from './podcasts-utils';
+
+export interface PodcastEpisode {
+  date: string;
+  duration: string;
+  episodeId: string;
+  title: string;
+}
 
 export interface Podcast {
   author: string;
@@ -13,6 +21,7 @@ export interface Podcast {
   description: string;
   podcastId: string;
   title: string;
+  episodes: PodcastEpisode[];
 }
 
 export const podcastsAdapter = createEntityAdapter<Podcast>({
@@ -45,6 +54,20 @@ export const podcastsSlice = createSlice({
     updateFilter(state, action) {
       state.filter = action.payload;
     },
+    savePodcastEpisodes(
+      state,
+      action: PayloadAction<{ podcastId: string; episodes: PodcastEpisode[] }>
+    ) {
+      const { podcastId, episodes } = action.payload;
+
+      const podcast = state.entities[podcastId];
+
+      if (podcast) {
+        podcast.episodes = episodes;
+      }
+
+      setStoredPodcasts(state);
+    },
   },
   extraReducers(builder) {
     builder.addCase(fetchPodcasts.pending, (state) => {
@@ -64,6 +87,6 @@ export const podcastsSlice = createSlice({
 
 const { reducer, actions } = podcastsSlice;
 
-export const { updateFilter } = actions;
+export const { updateFilter, savePodcastEpisodes } = actions;
 
 export default reducer;

--- a/src/features/podcasts/podcasts-slice.ts
+++ b/src/features/podcasts/podcasts-slice.ts
@@ -8,10 +8,11 @@ import { setStoredPodcasts } from 'app/storage';
 import { adaptPodcastFromResponse } from './podcasts-utils';
 
 export interface Podcast {
-  podcastId: string;
-  coverUrl: string;
-  title: string;
   author: string;
+  coverUrl: string;
+  description: string;
+  podcastId: string;
+  title: string;
 }
 
 export const podcastsAdapter = createEntityAdapter<Podcast>({

--- a/src/features/podcasts/podcasts-utils.ts
+++ b/src/features/podcasts/podcasts-utils.ts
@@ -1,8 +1,9 @@
 export const adaptPodcastFromResponse = (podcastData: any) => ({
-  author: podcastData['im:artist'].label,
-  coverUrl: podcastData['im:image'][2].label,
-  podcastId: podcastData.id.attributes['im:id'],
-  title: podcastData.title.label,
+  author: podcastData['im:artist'].label as string,
+  coverUrl: podcastData['im:image'][2].label as string,
+  description: podcastData.summary.label as string,
+  podcastId: podcastData.id.attributes['im:id'] as string,
+  title: podcastData['im:name'].label as string,
 });
 
 export const contains = (target: string, value: string = '') =>

--- a/src/features/podcasts/podcasts-utils.ts
+++ b/src/features/podcasts/podcasts-utils.ts
@@ -1,19 +1,38 @@
-export const adaptPodcastFromResponse = (podcastData: any) => ({
-  author: podcastData['im:artist'].label as string,
-  coverUrl: podcastData['im:image'][2].label as string,
-  description: podcastData.summary.label as string,
-  podcastId: podcastData.id.attributes['im:id'] as string,
-  title: podcastData['im:name'].label as string,
-});
+import { Podcast, PodcastEpisode } from './podcasts-slice';
+
+export const adaptPodcastFromResponse = (podcastData: any) =>
+  ({
+    author: String(podcastData['im:artist'].label),
+    coverUrl: String(podcastData['im:image'][2].label),
+    description: String(podcastData.summary.label),
+    podcastId: String(podcastData.id.attributes['im:id']),
+    title: String(podcastData['im:name'].label),
+    episodes: [],
+  } as Podcast);
 
 export const contains = (target: string, value: string = '') =>
   target.toLowerCase().includes(value.toLowerCase());
 
-export const adaptPodcastDetailsFromResponse = (podcastDetailsData: any) => ({
-  author: podcastDetailsData.artistName as string,
-  coverUrl: podcastDetailsData.artworkUrl600 as string,
-  description: 'Lorem ipsum',
-  episodes: [],
-  podcastId: podcastDetailsData.collectionId as string,
-  title: podcastDetailsData.collectionName as string,
-});
+// Borrowed from: https://stackoverflow.com/questions/29816872/how-can-i-convert-milliseconds-to-hhmmss-format-using-javascript
+export const formatDuration = (time: number) =>
+  new Date(time).toISOString().slice(11, 19);
+
+export const formatDate = (isoDate: string) =>
+  new Date(isoDate).toISOString().split('T')[0];
+
+export const adaptPodcastEpisodesFromResponse = (
+  podcastEpisodes: any[]
+): PodcastEpisode[] => {
+  if (Array.isArray(podcastEpisodes)) {
+    return podcastEpisodes
+      .filter((result) => result.wrapperType === 'podcastEpisode')
+      .map((episode) => ({
+        episodeId: String(episode.trackId),
+        title: String(episode.trackName),
+        duration: formatDuration(episode.trackTimeMillis as number),
+        date: formatDate(episode.releaseDate as string),
+      }));
+  }
+
+  return [];
+};

--- a/src/features/podcasts/podcasts-utils.ts
+++ b/src/features/podcasts/podcasts-utils.ts
@@ -7,3 +7,12 @@ export const adaptPodcastFromResponse = (podcastData: any) => ({
 
 export const contains = (target: string, value: string = '') =>
   target.toLowerCase().includes(value.toLowerCase());
+
+export const adaptPodcastDetailsFromResponse = (podcastDetailsData: any) => ({
+  author: podcastDetailsData.artistName as string,
+  coverUrl: podcastDetailsData.artworkUrl600 as string,
+  description: 'Lorem ipsum',
+  episodes: [],
+  podcastId: podcastDetailsData.collectionId as string,
+  title: podcastDetailsData.collectionName as string,
+});

--- a/src/mocks/faker.ts
+++ b/src/mocks/faker.ts
@@ -16,8 +16,11 @@ export const createFakePodcastData = (podcastId = nanoid()) => ({
       label: 'https://via.placeholder.com/170x170',
     },
   ],
-  title: {
-    label: `Podcast title ${podcastId}`,
+  'im:name': {
+    label: `Podcast title${podcastId}`,
+  },
+  summary: {
+    label: `Podcast summary ${podcastId}`,
   },
 });
 

--- a/src/pages/PodcastDetailsPage/PodcastDetailsPage.stories.tsx
+++ b/src/pages/PodcastDetailsPage/PodcastDetailsPage.stories.tsx
@@ -1,0 +1,38 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { PodcastDetailsPage } from './PodcastDetailsPage';
+import * as PodcastDetailsStories from 'features/podcasts/PodcastDetailsCard/PodcastDetailsCard.stories';
+
+export default {
+  title: 'Pages/PodcastDetailsPage',
+  component: PodcastDetailsPage,
+} as ComponentMeta<typeof PodcastDetailsPage>;
+
+const PodcastDetailsPageTemplate: ComponentStory<typeof PodcastDetailsPage> = (
+  props
+) => <PodcastDetailsPage {...props} />;
+
+export const Default = PodcastDetailsPageTemplate.bind({});
+
+Default.args = {
+  ...PodcastDetailsStories.Default.args,
+  episodes: [
+    {
+      date: '19/03/2023',
+      duration: '15:45',
+      episodeId: '1',
+      title: 'Episode 1',
+    },
+    {
+      date: '19/03/2023',
+      duration: '15:45',
+      episodeId: '2',
+      title: 'Episode 2',
+    },
+    {
+      date: '19/03/2023',
+      duration: '15:45',
+      episodeId: '3',
+      title: 'Episode 3',
+    },
+  ],
+};

--- a/src/pages/PodcastDetailsPage/PodcastDetailsPage.styles.ts
+++ b/src/pages/PodcastDetailsPage/PodcastDetailsPage.styles.ts
@@ -1,0 +1,36 @@
+import { PodcastDetailsCard } from 'features/podcasts/PodcastDetailsCard/PodcastDetailsCard';
+import { PodcastEpisodesTable } from 'features/podcasts/PodcastEpisodesTable/PodcastEpisodesTable';
+import { PodcastEpisodesTally } from 'features/podcasts/PodcastEpisodesTally/PodcastEpisodesTally';
+import styled from 'styled-components';
+
+export const PageContainer = styled.main`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  padding: 1rem;
+`;
+
+export const LeftSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  width: 30%;
+  min-width: 200px;
+  max-width: 300px;
+`;
+
+export const RightSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  width: 66%;
+  justify-self: flex-end;
+  margin-left: 10%;
+`;
+
+export const StyledPodcastDetails = styled(PodcastDetailsCard)``;
+
+export const StyledPodcastEpisodesTally = styled(PodcastEpisodesTally)`
+  margin-bottom: 2rem;
+`;
+
+export const StyledPodcastEpisodesTable = styled(PodcastEpisodesTable)``;

--- a/src/pages/PodcastDetailsPage/PodcastDetailsPage.styles.ts
+++ b/src/pages/PodcastDetailsPage/PodcastDetailsPage.styles.ts
@@ -22,9 +22,8 @@ export const RightSection = styled.section`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  width: 66%;
   justify-self: flex-end;
-  margin-left: 10%;
+  margin-left: 5%;
 `;
 
 export const StyledPodcastDetails = styled(PodcastDetailsCard)``;

--- a/src/pages/PodcastDetailsPage/PodcastDetailsPage.tsx
+++ b/src/pages/PodcastDetailsPage/PodcastDetailsPage.tsx
@@ -1,0 +1,53 @@
+import { PodcastDetailsCard } from 'features/podcasts/PodcastDetailsCard/PodcastDetailsCard';
+import { FC } from 'react';
+import {
+  LeftSection,
+  PageContainer,
+  RightSection,
+  StyledPodcastDetails,
+  StyledPodcastEpisodesTable,
+  StyledPodcastEpisodesTally,
+} from './PodcastDetailsPage.styles';
+
+interface PodcastDetailsPageProps
+  extends React.ComponentProps<typeof PodcastDetailsCard> {
+  episodes: {
+    episodeId: string;
+    date: string;
+    duration: string;
+    title: string;
+  }[];
+}
+
+export const PodcastDetailsPage: FC<PodcastDetailsPageProps> = ({
+  author,
+  coverUrl,
+  description,
+  episodes,
+  title,
+}) => (
+  <PageContainer>
+    <LeftSection>
+      <StyledPodcastDetails
+        author={author}
+        coverUrl={coverUrl}
+        description={description}
+        title={title}
+      />
+    </LeftSection>
+    <RightSection>
+      <StyledPodcastEpisodesTally tally={episodes.length} />
+      <StyledPodcastEpisodesTable>
+        {episodes.map((episode) => (
+          <StyledPodcastEpisodesTable.Row
+            date={episode.date}
+            duration={episode.duration}
+            episodeId={episode.episodeId}
+            key={episode.episodeId}
+            title={episode.title}
+          />
+        ))}
+      </StyledPodcastEpisodesTable>
+    </RightSection>
+  </PageContainer>
+);

--- a/src/pages/PodcastDetailsPage/PodcastDetailsPage.tsx
+++ b/src/pages/PodcastDetailsPage/PodcastDetailsPage.tsx
@@ -24,6 +24,7 @@ export const PodcastDetailsPage: FC<PodcastDetailsPageProps> = ({
   coverUrl,
   description,
   episodes,
+  podcastId,
   title,
 }) => (
   <PageContainer>
@@ -33,6 +34,7 @@ export const PodcastDetailsPage: FC<PodcastDetailsPageProps> = ({
         coverUrl={coverUrl}
         description={description}
         title={title}
+        podcastId={podcastId}
       />
     </LeftSection>
     <RightSection>

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,1 +1,2 @@
 export * from './HomePage/HomePage';
+export * from './PodcastDetailsPage/PodcastDetailsPage';

--- a/src/routes/HomePageRoute/HomePageRoute.tsx
+++ b/src/routes/HomePageRoute/HomePageRoute.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+import { useAppDispatch, useAppSelector } from 'app/hooks';
+import {
+  fetchPodcasts,
+  selectFilteredPodcasts,
+  selectFilter,
+  selectLastFetch,
+  selectStatus,
+  updateFilter,
+} from 'features/podcasts';
+import { HomePage } from 'pages';
+import { isWithin24Hours } from 'utils';
+
+export const HomePageRoute = () => {
+  const podcasts = useAppSelector(selectFilteredPodcasts);
+  const lastFetch = useAppSelector(selectLastFetch);
+  const podcastsStatus = useAppSelector(selectStatus);
+  const filterValue = useAppSelector(selectFilter);
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    if (podcastsStatus !== 'loading') {
+      if (!lastFetch || !isWithin24Hours(lastFetch)) {
+        dispatch(fetchPodcasts());
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onFilterChange: React.ChangeEventHandler<HTMLInputElement> = (
+    event
+  ) => {
+    dispatch(updateFilter(event.target.value));
+  };
+
+  return (
+    <HomePage
+      podcasts={podcasts}
+      filterResults={podcasts.length}
+      filterValue={filterValue}
+      onFilterChange={onFilterChange}
+    />
+  );
+};

--- a/src/routes/PodcastDetailsPageRoute/PodcastDetailsPageRoute.tsx
+++ b/src/routes/PodcastDetailsPageRoute/PodcastDetailsPageRoute.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { useParams, Navigate } from 'react-router-dom';
+
+import { client } from 'api/client';
+import { adaptPodcastDetailsFromResponse } from 'features/podcasts';
+import { PodcastDetailsPage } from 'pages';
+
+type RequestStatus = 'idle' | 'loading' | 'success' | 'error';
+
+type PodcastDetails = {
+  author: string;
+  coverUrl: string;
+  description: string;
+  episodes: {
+    date: string;
+    duration: string;
+    episodeId: string;
+    title: string;
+  }[];
+  podcastId: string;
+  title: string;
+};
+
+export const PodcastDetailsPageRoute = () => {
+  const [status, setStatus] = useState<RequestStatus>('idle');
+  const [podcastDetails, setPodcastDetails] = useState<PodcastDetails>();
+  const { podcastId } = useParams<{ podcastId: string }>();
+
+  useEffect(() => {
+    (async () => {
+      if (podcastId && status === 'idle') {
+        setStatus('loading');
+
+        try {
+          const response = await client.fetchPodcastDetails(podcastId);
+
+          if (response.data) {
+            setPodcastDetails(adaptPodcastDetailsFromResponse(response.data));
+          }
+
+          setStatus('success');
+        } catch (err) {
+          console.error(err);
+          setStatus('error');
+        }
+      }
+    })();
+  }, [podcastId, status]);
+
+  if (!podcastId) {
+    return <Navigate to={'/'} />;
+  }
+
+  if (status === 'loading') {
+    return <h2>Loading...</h2>;
+  }
+
+  return podcastDetails ? (
+    <PodcastDetailsPage
+      author={podcastDetails.author}
+      coverUrl={podcastDetails.coverUrl}
+      description={podcastDetails.description}
+      episodes={podcastDetails.episodes}
+      podcastId={podcastDetails.podcastId}
+      title={podcastDetails.title}
+    />
+  ) : (
+    <h2>Podcast '{podcastId}' not found.</h2>
+  );
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,1 +1,2 @@
 export * from './HomePageRoute/HomePageRoute';
+export * from './PodcastDetailsPageRoute/PodcastDetailsPageRoute';

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,0 +1,1 @@
+export * from './HomePageRoute/HomePageRoute';


### PR DESCRIPTION
This PR addresses the implementation of the Podcast Details page with the list of available episodes.

## Changelog

- Implementation of routes with React Router DOM.
- Refactor App in Pages and Routes.
- Update API client to fetch podcast details.
- Creation of the PodcastDetailsCard + stories.
- Creation of the PodcastEpisodesTable + stories.
- Creation of the PodcastTally + stories.
- Creation of the PodcastDetailsPage + stories.
- Refactor Podcast slice to include episodes.
- Add feature to persist already downloaded episodes.
- Minor updates in styles.

## Storybook

### PodcastDetailsCard

<img width="284" alt="image" src="https://user-images.githubusercontent.com/7682555/226477688-4abdb736-efe8-4199-b5d7-28b2cefd7262.png">

### PodcastEpisodesTable

<img width="571" alt="image" src="https://user-images.githubusercontent.com/7682555/226477755-af2326e8-030e-436f-98c0-f12c399bed1a.png">

### PodcastEpisodesTally

<img width="569" alt="image" src="https://user-images.githubusercontent.com/7682555/226477791-03edd5d6-956b-47dd-befc-b3ada98dbb74.png">

### PodcastDetailsPage

<img width="837" alt="image" src="https://user-images.githubusercontent.com/7682555/226477854-e1918e30-608b-4e50-bccc-52270235b5bf.png">

## App Screenshots

<img width="1100" alt="image" src="https://user-images.githubusercontent.com/7682555/226477992-b36f6f68-01ad-482f-8dfc-9702e786b7ad.png">
