### PR TITLE
Feature: Loading Spinner

### DIFF
--- a/src/App.styles.ts
+++ b/src/App.styles.ts
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+import { LoadingSpinner } from 'components';
+
+export const StyledSpinner = styled(LoadingSpinner)`
+  align-self: flex-end;
+`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,8 @@
 import { RouterProvider } from 'react-router-dom';
 import { router } from 'app/router';
-import { useAppSelector } from 'app/hooks';
-import { AppHeader, AppName } from 'components';
-import { selectStatus } from 'features/podcasts';
-import { StyledSpinner } from './App.styles';
 
 function App() {
-  const podcastsStatus = useAppSelector(selectStatus);
-
-  return (
-    <>
-      <AppHeader>
-        <AppName />
-        {podcastsStatus === 'loading' && <StyledSpinner />}
-      </AppHeader>
-      <RouterProvider router={router} />
-    </>
-  );
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,19 @@
 import { RouterProvider } from 'react-router-dom';
 import { router } from 'app/router';
-import { AppHeader } from 'components';
+import { useAppSelector } from 'app/hooks';
+import { AppHeader, AppName } from 'components';
+import { selectStatus } from 'features/podcasts';
+import { StyledSpinner } from './App.styles';
 
 function App() {
+  const podcastsStatus = useAppSelector(selectStatus);
+
   return (
     <>
-      <AppHeader />
+      <AppHeader>
+        <AppName />
+        {podcastsStatus === 'loading' && <StyledSpinner />}
+      </AppHeader>
       <RouterProvider router={router} />
     </>
   );

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,21 +1,27 @@
 import { createBrowserRouter } from 'react-router-dom';
 import {
   HomePageRoute,
+  Layout,
   PodcastDetailsPageRoute,
   PodcastEpisodePageRoute,
 } from 'routes';
 
 export const router = createBrowserRouter([
   {
-    path: '/',
-    element: <HomePageRoute />,
-  },
-  {
-    path: '/podcast/:podcastId',
-    element: <PodcastDetailsPageRoute />,
-  },
-  {
-    path: '/podcast/:podcastId/episode/:episodeId',
-    element: <PodcastEpisodePageRoute />,
+    element: <Layout />,
+    children: [
+      {
+        path: '/',
+        element: <HomePageRoute />,
+      },
+      {
+        path: '/podcast/:podcastId',
+        element: <PodcastDetailsPageRoute />,
+      },
+      {
+        path: '/podcast/:podcastId/episode/:episodeId',
+        element: <PodcastEpisodePageRoute />,
+      },
+    ],
   },
 ]);

--- a/src/components/AppHeader/AppHeader.stories.tsx
+++ b/src/components/AppHeader/AppHeader.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { AppName } from 'components';
 import { AppHeader } from './AppHeader';
 
 export default {
@@ -16,4 +17,6 @@ const AppHeaderTemplate: ComponentStory<typeof AppHeader> = (props) => (
 
 export const Default = AppHeaderTemplate.bind({});
 
-Default.args = {};
+Default.args = {
+  children: <AppName />,
+};

--- a/src/components/AppHeader/AppHeader.styles.ts
+++ b/src/components/AppHeader/AppHeader.styles.ts
@@ -4,10 +4,8 @@ export const StyledAppHeader = styled.header`
   align-items: center;
   background-color: ${({ theme }) => theme.palette.background};
   border-bottom: 1px solid gray;
-  color: ${({ theme }) => theme.palette.primary};
   display: flex;
-  font-size: 1.5rem;
-  font-weight: 600;
+  justify-content: space-between;
   padding: 0.9rem;
   position: sticky;
   top: 0;

--- a/src/components/AppHeader/AppHeader.test.tsx
+++ b/src/components/AppHeader/AppHeader.test.tsx
@@ -3,7 +3,7 @@ import { renderWithTheme, screen } from 'test/test-utils';
 
 describe('<AppHeader/>', () => {
   test('renders the app title', () => {
-    renderWithTheme(<AppHeader />);
+    renderWithTheme(<AppHeader>Podcaster</AppHeader>);
 
     expect(screen.getByText('Podcaster')).toBeInTheDocument();
   });

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -1,8 +1,6 @@
-import { FC } from 'react';
+import { PropsWithChildren } from 'react';
 import { StyledAppHeader } from './AppHeader.styles';
 
-interface AppHeaderProps {}
-
-export const AppHeader: FC<AppHeaderProps> = () => {
-  return <StyledAppHeader>Podcaster</StyledAppHeader>;
+export const AppHeader = ({ children }: PropsWithChildren) => {
+  return <StyledAppHeader>{children}</StyledAppHeader>;
 };

--- a/src/components/AppName/AppName.styles.ts
+++ b/src/components/AppName/AppName.styles.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const StyledAppName = styled.h1`
+  color: ${({ theme }) => theme.palette.primary};
+  font-size: 1.5rem;
+  font-weight: 600;
+`;

--- a/src/components/AppName/AppName.tsx
+++ b/src/components/AppName/AppName.tsx
@@ -1,0 +1,3 @@
+import { StyledAppName } from './AppName.styles';
+
+export const AppName = () => <StyledAppName>Podcaster</StyledAppName>;

--- a/src/components/LoadingSpinner/LoadingSpinner.stories.tsx
+++ b/src/components/LoadingSpinner/LoadingSpinner.stories.tsx
@@ -1,0 +1,9 @@
+import { ComponentMeta } from '@storybook/react';
+import { LoadingSpinner } from './LoadingSpinner';
+
+export default {
+  title: 'Components/LoadingSpinner',
+  component: LoadingSpinner,
+} as ComponentMeta<typeof LoadingSpinner>;
+
+export const Default = () => <LoadingSpinner />;

--- a/src/components/LoadingSpinner/LoadingSpinner.styles.ts
+++ b/src/components/LoadingSpinner/LoadingSpinner.styles.ts
@@ -1,0 +1,34 @@
+import styled, { keyframes } from 'styled-components';
+
+// A nice CSS loader borrowed from:
+// https://loading.io/css/
+const animation = keyframes`
+    0%, 100% {
+      animation-timing-function: cubic-bezier(0.5, 0, 1, 0.5);
+    }
+    0% {
+      transform: rotateY(0deg);
+    }
+    50% {
+      transform: rotateY(1800deg);
+      animation-timing-function: cubic-bezier(0, 0.5, 0.5, 1);
+    }
+    100% {
+      transform: rotateY(3600deg);
+    }
+`;
+
+export const Circle = styled.div`
+  display: inline-block;
+  transform: translateZ(1px);
+
+  & > div {
+    display: inline-block;
+    width: 64px;
+    height: 64px;
+    margin: 8px;
+    border-radius: 50%;
+    background: ${({ theme }) => theme.palette.primary};
+    animation: ${animation} 2.4s cubic-bezier(0, 0.2, 0.8, 1) infinite;
+  }
+`;

--- a/src/components/LoadingSpinner/LoadingSpinner.styles.ts
+++ b/src/components/LoadingSpinner/LoadingSpinner.styles.ts
@@ -18,15 +18,14 @@ const animation = keyframes`
     }
 `;
 
-export const Circle = styled.div`
+export const Circle = styled.div<{ size?: string }>`
   display: inline-block;
   transform: translateZ(1px);
 
   & > div {
     display: inline-block;
-    width: 64px;
-    height: 64px;
-    margin: 8px;
+    width: ${({ size = '1rem' }) => size};
+    height: ${({ size = '1rem' }) => size};
     border-radius: 50%;
     background: ${({ theme }) => theme.palette.primary};
     animation: ${animation} 2.4s cubic-bezier(0, 0.2, 0.8, 1) infinite;

--- a/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -1,0 +1,7 @@
+import { Circle } from './LoadingSpinner.styles';
+
+export const LoadingSpinner = () => (
+  <Circle>
+    <div></div>
+  </Circle>
+);

--- a/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -1,7 +1,7 @@
 import { Circle } from './LoadingSpinner.styles';
 
-export const LoadingSpinner = () => (
-  <Circle>
-    <div></div>
+export const LoadingSpinner = ({ className }: { className?: string }) => (
+  <Circle className={className}>
+    <div className="spinner" />
   </Circle>
 );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './AppHeader/AppHeader';
+export * from './AppName/AppName';
 export * from './LoadingSpinner/LoadingSpinner';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from './AppHeader/AppHeader';
+export * from './LoadingSpinner/LoadingSpinner';

--- a/src/features/podcasts/podcasts-slice.ts
+++ b/src/features/podcasts/podcasts-slice.ts
@@ -26,6 +26,8 @@ export interface Podcast {
   episodes: PodcastEpisode[];
 }
 
+type PodcastStatus = 'idle' | 'loading' | 'success' | 'error';
+
 export const podcastsAdapter = createEntityAdapter<Podcast>({
   selectId: (podcast) => podcast.podcastId,
 });
@@ -46,7 +48,7 @@ export const podcastsSlice = createSlice({
   initialState: podcastsAdapter.getInitialState<{
     filter: '';
     lastFetch: number | null;
-    status: 'idle' | 'loading' | 'success' | 'error';
+    status: PodcastStatus;
   }>({
     filter: '',
     lastFetch: null,
@@ -70,6 +72,9 @@ export const podcastsSlice = createSlice({
 
       setStoredPodcasts(state);
     },
+    updateStatus(state, action: PayloadAction<{ status: PodcastStatus }>) {
+      state.status = action.payload.status;
+    },
   },
   extraReducers(builder) {
     builder.addCase(fetchPodcasts.pending, (state) => {
@@ -89,6 +94,6 @@ export const podcastsSlice = createSlice({
 
 const { reducer, actions } = podcastsSlice;
 
-export const { updateFilter, savePodcastEpisodes } = actions;
+export const { updateFilter, savePodcastEpisodes, updateStatus } = actions;
 
 export default reducer;

--- a/src/routes/Layout/Layout.styles.ts
+++ b/src/routes/Layout/Layout.styles.ts
@@ -1,6 +1,12 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 import { LoadingSpinner } from 'components';
 
 export const StyledSpinner = styled(LoadingSpinner)`
   align-self: flex-end;
+`;
+
+export const StyledLink = styled(Link)`
+  color: inherit;
+  text-decoration: none;
 `;

--- a/src/routes/Layout/Layout.tsx
+++ b/src/routes/Layout/Layout.tsx
@@ -1,0 +1,21 @@
+import { Outlet } from 'react-router-dom';
+import { useAppSelector } from 'app/hooks';
+import { AppHeader, AppName } from 'components';
+import { selectStatus } from 'features/podcasts';
+import { StyledLink, StyledSpinner } from './Layout.styles';
+
+export const Layout = () => {
+  const podcastsStatus = useAppSelector(selectStatus);
+
+  return (
+    <>
+      <AppHeader>
+        <StyledLink to={'/'}>
+          <AppName />
+        </StyledLink>
+        {podcastsStatus === 'loading' && <StyledSpinner />}
+      </AppHeader>
+      <Outlet />
+    </>
+  );
+};

--- a/src/routes/PodcastDetailsPageRoute/PodcastDetailsPageRoute.tsx
+++ b/src/routes/PodcastDetailsPageRoute/PodcastDetailsPageRoute.tsx
@@ -1,34 +1,34 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 
+import { useAppDispatch, useAppSelector } from 'app/hooks';
 import { client } from 'api/client';
 import {
   adaptPodcastEpisodesFromResponse,
   selectPodcastById,
   savePodcastEpisodes,
+  updateStatus,
+  selectStatus,
 } from 'features/podcasts';
 import { PodcastDetailsPage } from 'pages';
-import { useAppDispatch, useAppSelector } from 'app/hooks';
-
-type RequestStatus = 'idle' | 'loading' | 'success' | 'error';
 
 export const PodcastDetailsPageRoute = () => {
   const { podcastId } = useParams<{ podcastId: string }>();
   const podcast = useAppSelector((state) =>
     selectPodcastById(state, String(podcastId))
   );
-  const [status, setStatus] = useState<RequestStatus>('idle');
+  const status = useAppSelector(selectStatus);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
     (async () => {
-      if (podcast && podcast.episodes.length === 0 && status === 'idle') {
-        setStatus('loading');
+      if (podcast && podcast.episodes.length === 0 && status !== 'loading') {
+        dispatch(updateStatus({ status: 'loading' }));
 
         try {
           const response = await client.fetchPodcastDetails(podcast.podcastId);
 
-          setStatus('success');
+          dispatch(updateStatus({ status: 'success' }));
 
           const episodes = adaptPodcastEpisodesFromResponse(response.data);
 
@@ -37,7 +37,7 @@ export const PodcastDetailsPageRoute = () => {
           );
         } catch (err) {
           console.error(err);
-          setStatus('error');
+          dispatch(updateStatus({ status: 'error' }));
         }
       }
     })();

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,3 +1,4 @@
 export * from './HomePageRoute/HomePageRoute';
+export * from './Layout/Layout';
 export * from './PodcastDetailsPageRoute/PodcastDetailsPageRoute';
 export * from './PodcastEpisodePageRoute/PodcastEpisodePageRoute';


### PR DESCRIPTION
This PR addresses the implementation of a loading spinner when the app is busy fetching data.

## Changelog

- Create LoadingSpinner + stories.
- Create AppName.
- Refactor AppHeader.
- Implement a routing Layout so navigation from the AppHeader is possible.
- Implement LoadingSpinner in the AppHeader when podcast status is loading.
- Refactor the loading status for the PodcastEpisodePageRouter.

## Storybook

### LoadingSpinner

<img width="33" alt="image" src="https://user-images.githubusercontent.com/7682555/226497979-8ce1ae41-1261-4e54-962a-e601a8d3738e.png">

## App Screenshot

<img width="680" alt="image" src="https://user-images.githubusercontent.com/7682555/226498240-b635d119-9356-475b-87a2-137ee89cc44e.png">
